### PR TITLE
Update init.pp

### DIFF
--- a/rabbitmq/manifests/init.pp
+++ b/rabbitmq/manifests/init.pp
@@ -1,7 +1,4 @@
 class rabbitmq (
-  Array     $deprecated_features  = [
-    'transient_nonexcl_queues',
-  ],
   String    $target               = 'services',
   Integer   $nice_level           = 12,
   Integer   $limit_file           = 10000
@@ -84,17 +81,6 @@ class rabbitmq (
     group   => 'rabbitmq',
     mode    => '0700',
     require => Package['rabbitmq-server'],
-  }
-
-  # Create deprecated_features conf
-  file { '/etc/rabbitmq/conf.d/deprecated_features.conf':
-    ensure  => file,
-    content => template('rabbitmq/deprecated_features.conf'),
-    owner   => 'rabbitmq',
-    group   => 'rabbitmq',
-    mode    => '0600',
-    notify  => Service['rabbitmq-server'],
-    require => File['rabbitmq_config_dir'],
   }
 
   # Create ssl directory


### PR DESCRIPTION
Removed deprecated array, due to failure to start rabbitmq-server service with the error 'setting does not exist'.