### PR TITLE
Made the jvm memory config adjustable to machine preferences.

### DIFF
--- a/basic_settings/manifests/init.pp
+++ b/basic_settings/manifests/init.pp
@@ -54,6 +54,7 @@ class basic_settings (
   Boolean                               $proxmox_enable                             = false,
   Optional[Enum['distro','remote']]     $puppet_repo                                = undef,
   Boolean                               $puppetserver_enable                        = false,
+  Enum['512mb','1gb','2gb']             $puppetserver_jvm_memory                    = '2gb',
   Enum['openvox','perforce']            $puppetserver_source                        = 'perforce',
   Boolean                               $rabbitmq_enable                            = false,
   String                                $server_fdqn                                = $facts['networking']['fqdn'],
@@ -854,10 +855,11 @@ class basic_settings (
 
   # Setup Puppet
   class { 'basic_settings::puppet':
-    repo           => $puppet_repo_correct,
-    server_dirname => $puppetserver_dirname,
-    server_enable  => $puppetserver_enable,
-    server_package => $puppetserver_package,
+    jvm_memory      => $puppetserver_jvm_memory,
+    repo            => $puppet_repo_correct,
+    server_dirname  => $puppetserver_dirname,
+    server_enable   => $puppetserver_enable,
+    server_package  => $puppetserver_package,
   }
 
   # Setup login

--- a/basic_settings/manifests/puppet.pp
+++ b/basic_settings/manifests/puppet.pp
@@ -1,12 +1,13 @@
 class basic_settings::puppet (
-  Enum['distro', 'remote']              $repo           = 'distro',
-  Boolean                               $server_enable  = false,
+  Enum['512mb','1gb','2gb']             $jvm_memory         = '2gb',
+  Enum['distro', 'remote']              $repo               = 'distro',
+  Boolean                               $server_enable      = false,
   Enum[
     'openvox-server',
     'puppet-master',
     'puppetserver'
-  ]                                     $server_package = 'puppetserver',
-  String                                $server_dirname = 'puppetserver',
+  ]                                     $server_package     = 'puppetserver',
+  String                                $server_dirname     = 'puppetserver',
 ) {
   # Set some values
   $basic_settings_enable = defined(Class['basic_settings'])

--- a/basic_settings/templates/puppet/environment
+++ b/basic_settings/templates/puppet/environment
@@ -6,7 +6,16 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
+<% case @jvm_memory 
+   when '512mb' %>
+JAVA_ARGS="-Xms512m -Xmx512m -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger -Djava.io.tmpdir=<%= @server_var_extra %>/temp"
+<% when '1gb' %>
+JAVA_ARGS="-Xms1g -Xmx1g -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger -Djava.io.tmpdir=<%= @server_var_extra %>/temp"
+<% when '2gb' %>
 JAVA_ARGS="-Xms2g -Xmx2g -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger -Djava.io.tmpdir=<%= @server_var_extra %>/temp"
+<% else %>
+<% raise "Unsupported value: #{@jvm_memory}" %>
+<% end %>
 
 # Modify this as you would JAVA_ARGS but for non-service related subcommands
 JAVA_ARGS_CLI="${JAVA_ARGS_CLI:-}"


### PR DESCRIPTION
- Created puppetserver_jvm_memory in basic_settings class
- Created jvm_memory enum in basic_settings::puppet
- Created jvm_memory switch/case in template/puppet/environment template
- 2gb default
